### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -17,6 +17,13 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
+    # @user = Item.find(params[:id])
+    # @user = User.new
+    # @items = @user.items.include(:user)
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,9 +21,6 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    # @user = Item.find(params[:id])
-    # @user = User.new
-    # @items = @user.items.include(:user)
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,10 +128,10 @@
     </div>
     <ul class='item-lists'>
       <% @items.each do |item| %> 
-        <li class='list'>       
-          <%= link_to '#' do %> 
+        <li class='list'> 
+          <%= link_to item_path(item), method: :get do %> 
           <div class='item-img-content'>
-            <%= link_to image_tag(item.image.variant(resize: '200x300'), class: "item_img" ), '#' %>
+            <%= link_to image_tag(item.image.variant(resize: '200x300'), class: "item_img" ), item_path(item) %>
 
             <%# 商品が売れていればsold outを表示しましょう %>
               <div class='sold-out'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,118 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.item_name %>
+    </h2>
+    <div class="item-img-content">
+        <%# "item-sample.png" , %>
+      <%# <%= link_to image_tag(item.image.variant(resize: '200x300'), class: "item_img" ), item_path(item) %>
+      <%= image_tag(@item.image.variant(resize: '200x300'), class:"item-box-img" ) %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <div class="sold-out">
+        <span>Sold Out!!</span>
+      </div>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= @item.price %>円
+      </span>
+      <span class="item-postage">
+        <%= @item.delivery_charge.name %>
+      </span>
+    </div>
+
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# <% if 'ユーザーがログインしている 且つ 商品が出品中である(あとで追加)' %> 
+    <% if user_signed_in? %> 
+      <% if  current_user.id == @item.user_id %> 
+        <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %> 
+        <%# <% if  current_user == @item.user_id %> 
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else %>
+            <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+            <%# //商品が売れていない場合はこちらを表示しましょう %> 
+      <% end %>
+    <% end %>  
+
+    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+    <div class="item-explain-box">
+      <span><%= "商品説明" %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <%# @item.nickname.user_id %>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @item.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @item.detail.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @item.delivery_charge.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @item.number_day.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -44,7 +44,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -110,9 +110,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
   
-  resources :items, only: [:index, :new, :create ] 
+  resources :items, only: [:index, :new, :create,:show ]
 end
 
-# resources :users, only: :index
+
+# resources :user, only: [:show] 


### PR DESCRIPTION
# What
トップページの商品から詳細ページへの遷移機能、詳細画面での商品情報の表示、条件分岐による商品詳細画面内のボタン(編集・削除・購入)表示

#Why
商品詳細表示機能の実装のため

以下動画です。
よろしくお願い致します。

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページに遷移
https://i.gyazo.com/b7375cab4be13ad8244659658cca40dd.gif

ログイン状態且つ、自身が出品していない商品の商品詳細ページに遷移
https://i.gyazo.com/b959707527c8ff5eeb14c2e5b7aa0e3d.gif

ログアウト状態で商品詳細ページに遷移
https://i.gyazo.com/c9fc13c11d32a7bb51e92143551468b3.gif